### PR TITLE
fix: resolve Coder HTTPS, OAuth, and NLB connectivity issues

### DIFF
--- a/GITHUB_APP_SETUP.md
+++ b/GITHUB_APP_SETUP.md
@@ -5,11 +5,13 @@
 When configuring your GitHub App for Coder, use these **exact** callback URLs:
 
 ### Primary OAuth (User Authentication)
+
 ```
 https://coderdemo.io/api/v2/users/oauth2/github/callback
 ```
 
 ### External Auth (Git Operations in Workspaces)
+
 ```
 https://coderdemo.io/api/v2/external-auth/primary-github/callback
 ```
@@ -22,7 +24,6 @@ https://coderdemo.io/api/v2/external-auth/primary-github/callback
 2. **Permissions Required**:
    - **Account permissions**:
      - Email addresses: Read-only
-   
    - **Repository permissions**:
      - Contents: Read and write
      - Metadata: Read-only (auto-required)
@@ -36,16 +37,19 @@ https://coderdemo.io/api/v2/external-auth/primary-github/callback
 ## Common Issues
 
 ### "redirect_uri is not associated with this application"
+
 - **Cause**: Callback URLs don't match what Coder is sending
 - **Solution**: Verify the URLs above are **exactly** correct (including `/api/v2/users/` and `/api/v2/`)
 
 ### "Not HTTPS Secure" warning
+
 - **Cause**: Accessing `http://coderdemo.io` instead of `https://coderdemo.io`
 - **Solution**: Always use `https://` when accessing Coder
 
 ## After Setup
 
 Once configured, users can:
+
 - Log into Coder using GitHub authentication
 - Clone repositories in their workspaces
 - Push/pull code

--- a/GITHUB_APP_SETUP.md
+++ b/GITHUB_APP_SETUP.md
@@ -1,0 +1,52 @@
+# GitHub App Setup for Coder
+
+## Correct Callback URLs
+
+When configuring your GitHub App for Coder, use these **exact** callback URLs:
+
+### Primary OAuth (User Authentication)
+```
+https://coderdemo.io/api/v2/users/oauth2/github/callback
+```
+
+### External Auth (Git Operations in Workspaces)
+```
+https://coderdemo.io/api/v2/external-auth/primary-github/callback
+```
+
+## Important Settings
+
+1. **Request user authorization (OAuth) during installation**: ✅ **MUST be checked**
+   - This allows users to log into Coder with their GitHub identity
+
+2. **Permissions Required**:
+   - **Account permissions**:
+     - Email addresses: Read-only
+   
+   - **Repository permissions**:
+     - Contents: Read and write
+     - Metadata: Read-only (auto-required)
+     - Pull requests: Read and write (optional, for PR creation)
+     - Issues: Read and write (optional, for issue management)
+
+3. **Installation**:
+   - Install the app to your account/organization
+   - Grant access to "All repositories" or specific repos
+
+## Common Issues
+
+### "redirect_uri is not associated with this application"
+- **Cause**: Callback URLs don't match what Coder is sending
+- **Solution**: Verify the URLs above are **exactly** correct (including `/api/v2/users/` and `/api/v2/`)
+
+### "Not HTTPS Secure" warning
+- **Cause**: Accessing `http://coderdemo.io` instead of `https://coderdemo.io`
+- **Solution**: Always use `https://` when accessing Coder
+
+## After Setup
+
+Once configured, users can:
+- Log into Coder using GitHub authentication
+- Clone repositories in their workspaces
+- Push/pull code
+- Create pull requests (if permissions granted)

--- a/infra/aws/eu-west-2/k8s/cert-manager/main.tf
+++ b/infra/aws/eu-west-2/k8s/cert-manager/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/coder-proxy/main.tf
+++ b/infra/aws/eu-west-2/k8s/coder-proxy/main.tf
@@ -3,9 +3,9 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
-    helm = {
+   helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -120,7 +120,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/coder-proxy/main.tf
+++ b/infra/aws/eu-west-2/k8s/coder-proxy/main.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
-   helm = {
+    helm = {
       source  = "hashicorp/helm"
       version = "3.1.1"
     }

--- a/infra/aws/eu-west-2/k8s/coder-ws/main.tf
+++ b/infra/aws/eu-west-2/k8s/coder-ws/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -98,7 +98,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/ebs-controller/main.tf
+++ b/infra/aws/eu-west-2/k8s/ebs-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -55,7 +55,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/karpenter/main.tf
+++ b/infra/aws/eu-west-2/k8s/karpenter/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -54,7 +54,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/lb-controller/main.tf
+++ b/infra/aws/eu-west-2/k8s/lb-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/eu-west-2/k8s/metrics-server/main.tf
+++ b/infra/aws/eu-west-2/k8s/metrics-server/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
   }
   backend "s3" {}
@@ -48,7 +48,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-east-2/k8s/cert-manager/main.tf
+++ b/infra/aws/us-east-2/k8s/cert-manager/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-east-2/k8s/coder-ws/main.tf
+++ b/infra/aws/us-east-2/k8s/coder-ws/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -98,7 +98,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-east-2/k8s/ebs-controller/main.tf
+++ b/infra/aws/us-east-2/k8s/ebs-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-east-2/k8s/karpenter/main.tf
+++ b/infra/aws/us-east-2/k8s/karpenter/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-       version = "3.1.1"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/infra/aws/us-east-2/k8s/lb-controller/main.tf
+++ b/infra/aws/us-east-2/k8s/lb-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-east-2/k8s/litellm/main.tf
+++ b/infra/aws/us-east-2/k8s/litellm/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
   }
   backend "s3" {}

--- a/infra/aws/us-east-2/k8s/metrics-server/main.tf
+++ b/infra/aws/us-east-2/k8s/metrics-server/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
   }
   backend "s3" {}
@@ -48,7 +48,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/cert-manager/main.tf
+++ b/infra/aws/us-west-2/k8s/cert-manager/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/coder-proxy/main.tf
+++ b/infra/aws/us-west-2/k8s/coder-proxy/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -120,7 +120,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/coder-ws/main.tf
+++ b/infra/aws/us-west-2/k8s/coder-ws/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -98,7 +98,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/ebs-controller/main.tf
+++ b/infra/aws/us-west-2/k8s/ebs-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -55,7 +55,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/karpenter/main.tf
+++ b/infra/aws/us-west-2/k8s/karpenter/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -68,7 +68,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/lb-controller/main.tf
+++ b/infra/aws/us-west-2/k8s/lb-controller/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
@@ -60,7 +60,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/infra/aws/us-west-2/k8s/metrics-server/main.tf
+++ b/infra/aws/us-west-2/k8s/metrics-server/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
   }
   backend "s3" {}
@@ -48,7 +48,7 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = data.aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/modules/k8s/bootstrap/cert-manager/main.tf
+++ b/modules/k8s/bootstrap/cert-manager/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/coder-provisioner/main.tf
+++ b/modules/k8s/bootstrap/coder-provisioner/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/coder-proxy/main.tf
+++ b/modules/k8s/bootstrap/coder-proxy/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/coder-server/main.tf
+++ b/modules/k8s/bootstrap/coder-server/main.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/ebs-controller/main.tf
+++ b/modules/k8s/bootstrap/ebs-controller/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/karpenter/main.tf
+++ b/modules/k8s/bootstrap/karpenter/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/lb-controller/main.tf
+++ b/modules/k8s/bootstrap/lb-controller/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/modules/k8s/bootstrap/metrics-server/main.tf
+++ b/modules/k8s/bootstrap/metrics-server/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.17.0"
+      version = "3.1.1"
     }
   }
 }


### PR DESCRIPTION
## Infrastructure Improvements

### Load Balancer & Networking
- Enable cross-zone load balancing for reduced latency
- Add explicit subnet annotations for all 3 availability zones (us-east-2a/b/c)
- Disable deletion protection for easier testing/iteration
- Add post-deployment service patch to fix HTTPS→HTTP port mapping

### TLS & Security Configuration
- Configure Coder for TLS-terminating NLB:
  - Set CODER_TLS_ENABLE=false (NLB handles TLS)
  - Enable CODER_SECURE_AUTH_COOKIE=true for HTTPS
  - Keep CODER_REDIRECT_TO_ACCESS_URL=false to prevent redirect loops

### OAuth & Authentication
- Enable oauth2 experiment for GitHub authentication
- Update GitHub App credentials
- Add GITHUB_APP_SETUP.md with correct callback URLs:
  - /api/v2/users/oauth2/github/callback
  - /api/v2/external-auth/primary-github/callback

### Provider Consistency
- Upgrade all Helm providers from 2.17.0 → 3.1.1 (22 files)
- Update Helm provider syntax for v3 compatibility (kubernetes { → kubernetes = {)
- Standardize versions across all regions (us-east-2, us-west-2, eu-west-2)

## Fixes
- Resolved "Target.NotInUse" errors (NLB/node AZ mismatch)
- Fixed HTTPS connectivity (port 443 now routes to HTTP backend correctly)
- Fixed GitHub OAuth redirect_uri errors
- Eliminated infinite page loading on HTTPS

## Files Changed
- 30 Terraform configurations updated
- 1 documentation file added (GITHUB_APP_SETUP.md)

🤖 Generated with Claude Code